### PR TITLE
installd: Use -f (force overwrite) for aapt

### DIFF
--- a/cmds/installd/commands.cpp
+++ b/cmds/installd/commands.cpp
@@ -1724,6 +1724,7 @@ static void run_aapt(const char *source_apk, const char *internal_path,
                               "-I", common_res_path,
                               "-r", resapk_str,
                               "-x", pkgId_str,
+                              "-f",
                               (char*)NULL);
     } else {
         execl(AAPT_BIN, AAPT_BIN, "package",
@@ -1734,6 +1735,7 @@ static void run_aapt(const char *source_apk, const char *internal_path,
                               "-I", FRAMEWORK_RES,
                               "-r", resapk_str,
                               "-x", pkgId_str,
+                              "-f",
                               (char*)NULL);
     }
     ALOGE("execl(%s) failed: %s\n", AAPT_BIN, strerror(errno));


### PR DESCRIPTION
When re-creating resource apks for themes, aapt will fail if the
apk already exists unless we use -f

Change-Id: If2c3a634aa3ca061009aa6892530d643f8f67e9f
