### PR TITLE
libbinder: allow devices to disable ashmem size tracking

### DIFF
--- a/include/binder/Parcel.h
+++ b/include/binder/Parcel.h
@@ -340,8 +340,10 @@ public:
         inline void* data() { return mData; }
     };
 
+#ifndef DISABLE_ASHMEM_TRACKING
 private:
     size_t mBlobAshmemSize;
+#endif
 
 public:
     size_t getBlobAshmemSize() const;

--- a/libs/binder/Parcel.cpp
+++ b/libs/binder/Parcel.cpp
@@ -922,9 +922,9 @@ status_t Parcel::writeBlob(size_t len, bool mutableCopy, WritableBlob* outBlob)
     ALOGV("writeBlob: write to ashmem");
     int fd = ashmem_create_region("Parcel Blob", len);
     if (fd < 0) return NO_MEMORY;
-
+#ifndef DISABLE_ASHMEM_TRACKING
     mBlobAshmemSize += len;
-
+#endif
     int result = ashmem_set_prot_region(fd, PROT_READ | PROT_WRITE);
     if (result < 0) {
         status = result;
@@ -1890,7 +1890,9 @@ void Parcel::initState()
     mFdsKnown = true;
     mAllowFds = true;
     mOwner = NULL;
+#ifndef DISABLE_ASHMEM_TRACKING
     mBlobAshmemSize = 0;
+#endif
 }
 
 void Parcel::scanForFds() const
@@ -1910,7 +1912,11 @@ void Parcel::scanForFds() const
 
 size_t Parcel::getBlobAshmemSize() const
 {
+#ifndef DISABLE_ASHMEM_TRACKING
     return mBlobAshmemSize;
+#else
+    return 0;
+#endif
 }
 
 // --- Parcel::Blob ---


### PR DESCRIPTION
The addition of ashmem size tracking can lead to parcel objects
overwriting other values on the stack in old binary blobs.

Change-Id: Ida52cec851a6f9d5a57c8f9130a5875c03dcb094
